### PR TITLE
Udp sim

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
   - pip install codecov
 
 script:
+  - flake8 $TRAVIS_BUILD_DIR/pygerm
   - coverage run run_tests.py
   - coverage report -m
   - set -e

--- a/cli/det_sim.py
+++ b/cli/det_sim.py
@@ -95,8 +95,8 @@ def simulate_line(n, c):
         This should create a curve that goes sinusoidally as the channel #.
         (But same for all chip numbers)
     '''
-    chan = c%n_chans
-    chip = c//n_chans
+    chan = c % n_chans
+    # chip = c // n_chans
 
     chan = chan.astype(float)
     # just make sinusoidal wave
@@ -105,6 +105,7 @@ def simulate_line(n, c):
 
 def simulate_random(n):
     return np.random.randint(0, high=2**12 + 1, size=n, dtype=np.uint32)
+
 
 def bin2num(*args):
     ''' Convenience routine to convert binary digits to decimal.
@@ -120,7 +121,6 @@ def bin2num(*args):
     for i, arg in enumerate(args):
         res += arg*2**i
     return res
-
 
 
 def make_sim_payload(num, n_chips, n_chans, tick_gap, ts_offset):
@@ -154,7 +154,7 @@ def make_sim_payload(num, n_chips, n_chans, tick_gap, ts_offset):
 
     # choose a random pixel id
     # n_chips, n_chans are 12, 32 (or see var set above)
-    #  
+    #
     # this gives 383 (binary to number) Commenting out and hard coding
     # to be safe
     # MAX_ID = bin2num(1, 0,1,1,1, 1,1,1,1)
@@ -220,7 +220,8 @@ async def recv_and_process():
                 # special case packet 0
                 tail = payload
                 head, tail = tail[:1020], tail[1020:]
-                # 'x' is a pad byte, xxxx is same size as I (4 byte unsigned int)
+                # 'x' is a pad byte, xxxx is same size as I (4 byte unsigned
+                # int)
                 # packets are 1024*4 bytes long total, first four unsigned ints
                 # (4 bytes each) are here, rest is data
                 header = struct.pack('!IIIxxxx',
@@ -234,7 +235,7 @@ async def recv_and_process():
                 first_head = 1022 - len(tail)
                 head = (tail, payload[:first_head])
                 tail = payload[first_head:]
-                # 2 unsigned ints I and xxxx 
+                # 2 unsigned ints I and xxxx
                 header = struct.pack('!Ixxxx', udp_packet_count)
                 udp.send(b''.join((header,
                                    bytes(head[0]),
@@ -243,7 +244,7 @@ async def recv_and_process():
 
             while len(tail) > 1022:
                 head, tail = tail[:1022], tail[1022:]
-                # 2 unsigned ints I and xxxx 
+                # 2 unsigned ints I and xxxx
                 header = struct.pack('!Ixxxx', udp_packet_count)
                 udp.send(b''.join((header, bytes(head))))
                 udp_packet_count += 1

--- a/cli/det_sim.py
+++ b/cli/det_sim.py
@@ -91,16 +91,20 @@ n_chans = 32
 def simulate_line(n, c):
     ''' simulate a line based on channel position c.
         data type is not assumed here, typecast when receiving it.
+
+        This should create a curve that goes sinusoidally as the channel #.
+        (But same for all chip numbers)
     '''
-    c = c.astype(float)
-    return np.clip(
-        (0.5 + 0.4 * np.sin((2*np.pi * 3 / (12*32)) * c)) *
-        ((2**7 * np.random.randn(n)) + 2**11),
-        0, 2**12 - 1)
+    chan = c%n_chans
+    chip = c//n_chans
+
+    chan = chan.astype(float)
+    # just make sinusoidal wave
+    return (np.abs(np.sin((chan/n_chans)*2*np.pi))*(2**12-1)).astype(np.uint32)
 
 
 def simulate_random(n):
-    return np.random.randint(2**12, size=n, dtype=np.uint64)
+    return np.random.randint(0, high=2**12 + 1, size=n, dtype=np.uint32)
 
 def bin2num(*args):
     ''' Convenience routine to convert binary digits to decimal.
@@ -157,12 +161,12 @@ def make_sim_payload(num, n_chips, n_chans, tick_gap, ts_offset):
     MAX_ID = 383
 
     # for debugging, could change this to some other non-uniform function
-    pix_id = np.random.randint(0, MAX_ID, size=num).astype('<u4')
+    pix_id = np.random.randint(0, high=MAX_ID+1, size=num).astype('<u4')
     chip_id = pix_id // n_chans
     chan_id = pix_id % n_chans
 
     # fine timestamp
-    td = np.random.randint(2**10, size=num, dtype='<u4')
+    td = np.random.randint(0, high=2**10+1, size=num, dtype='<u4')
 
     # energy
     # simulate a resonable looking energy by giving detector position

--- a/pygerm/client/__init__.py
+++ b/pygerm/client/__init__.py
@@ -2,34 +2,6 @@ import numpy as np
 from collections import OrderedDict
 
 
-def parse_event_payload(data):
-    '''Split up the raw data coming over the socket.
-
-    The documentation describes the data as 2 32 bit words with have
-    been merged here into a single 64 bit value.
-
-    The layout is
-
-       "0" [[4 bit chip addr] [5 bit channel addr]] [10 bit TD] [12 bit PD]
-       "100" [28 bit time stamp]
-
-    '''
-
-    # TODO sort out if this can be made faster!
-
-    # chip addr
-    chip = (data >> (27)) & 0xf
-    # chan addr
-    chan = (data >> (22)) & 0x1f
-    # fine ts
-    td = (data >> (12)) & 0x3ff
-    # evergy readings
-    pd = (data) & 0xfff
-    # FPGA tick
-    ts = data >> 32 & 0x7fffffff
-
-    return chip, chan, td, pd, ts
-
 def payload2event(data):
     '''Split up the raw data coming over the socket.
 
@@ -45,7 +17,7 @@ def payload2event(data):
 
     # TODO sort out if this can be made faster!
     word1 = data[::2]
-    word2 = data[::2]
+    word2 = data[1::2]
 
     # chip addr
     chip = word1 >> 27 & 0xf
@@ -86,7 +58,7 @@ def event2payload(chip, chan, td, pd, ts):
     payload = np.zeros(len(chip)*2, dtype='<u4')
     # TODO sort out if this can be made faster!
     #word1 = data[::2]
-    #word2 = data[::2]
+    #word2 = data[1::2]
     # for word 1
     payload[::2] = (chip << 27) + (chan << 22) + (td << 12)  + pd
     # for word 2

--- a/pygerm/client/__init__.py
+++ b/pygerm/client/__init__.py
@@ -24,8 +24,7 @@ def payload2event(data):
     # chan addr
     chan = word1 >> 22 & 0x1f
     # fine ts
-    # TODO : why 0x3ff not 1ff??
-    td = word1 >> 12 & 0x1ff
+    td = word1 >> 12 & 0x3ff
 
     # evergy readings
     pd = word1 & 0xfff

--- a/pygerm/client/__init__.py
+++ b/pygerm/client/__init__.py
@@ -30,7 +30,7 @@ def parse_event_payload(data):
 
     return chip, chan, td, pd, ts
 
-def parse_event_payload2(data):
+def payload2event(data):
     '''Split up the raw data coming over the socket.
 
     The documentation describes the data as 2 32 bit words with have
@@ -64,6 +64,35 @@ def parse_event_payload2(data):
 
     return chip, chan, td, pd, ts
 
+
+def event2payload(chip, chan, td, pd, ts):
+    ''' Convert event data to a payload.
+
+
+    This just creates words of the form:
+
+       "0" [[4 bit chip addr] [5 bit channel addr]] [10 bit TD] [12 bit PD]
+       "100" [28 bit time stamp]
+
+    Notes
+    -----
+        This does not include the header and footer.
+        The data is outputted as little endian by default.
+        Note that endianness matters only when this is sent to a buffer (file
+        network etc)
+    '''
+    # insigned little-endian, default
+    # 2 words of 32 bit per data
+    payload = np.zeros(len(chip)*2, dtype='<u4')
+    # TODO sort out if this can be made faster!
+    #word1 = data[::2]
+    #word2 = data[::2]
+    # for word 1
+    payload[::2] = (chip << 27) + (chan << 22) + (td << 12)  + pd
+    # for word 2
+    payload[1::2] = 1 << 31 + ts
+
+    return payload
 
 
 DATA_TYPES = OrderedDict((('chip', 8),

--- a/pygerm/client/__init__.py
+++ b/pygerm/client/__init__.py
@@ -11,7 +11,7 @@ def parse_event_payload(data):
     The layout is
 
        "0" [[4 bit chip addr] [5 bit channel addr]] [10 bit TD] [12 bit PD]
-       "1" [31 bit time stamp]
+       "100" [28 bit time stamp]
 
     '''
 
@@ -29,6 +29,41 @@ def parse_event_payload(data):
     ts = data >> 32 & 0x7fffffff
 
     return chip, chan, td, pd, ts
+
+def parse_event_payload2(data):
+    '''Split up the raw data coming over the socket.
+
+    The documentation describes the data as 2 32 bit words with have
+    been merged here into a single 64 bit value.
+
+    The layout is
+
+       "0" [[4 bit chip addr] [5 bit channel addr]] [10 bit TD] [12 bit PD]
+       "100" [28 bit time stamp]
+
+    '''
+
+    # TODO sort out if this can be made faster!
+    word1 = data[::2]
+    word2 = data[::2]
+
+    # chip addr
+    chip = word1 >> 27 & 0xf
+    # chan addr
+    chan = word1 >> 22 & 0x1f
+    # fine ts
+    # TODO : why 0x3ff not 1ff??
+    td = word1 >> 12 & 0x1ff
+
+    # evergy readings
+    pd = word1 & 0xfff
+
+    # FPGA tick
+    # should be 6 f's not 7??
+    ts = word2 & 0x7ffffff
+
+    return chip, chan, td, pd, ts
+
 
 
 DATA_TYPES = OrderedDict((('chip', 8),

--- a/pygerm/client/__init__.py
+++ b/pygerm/client/__init__.py
@@ -11,7 +11,7 @@ def payload2event(data):
     The layout is
 
        "0" [[4 bit chip addr] [5 bit channel addr]] [10 bit TD] [12 bit PD]
-       "100" [28 bit time stamp]
+       "1000" [28 bit time stamp]
 
     '''
 
@@ -44,7 +44,7 @@ def event2payload(chip, chan, td, pd, ts):
     This just creates words of the form:
 
        "0" [[4 bit chip addr] [5 bit channel addr]] [10 bit TD] [12 bit PD]
-       "100" [28 bit time stamp]
+       "1000" [28 bit time stamp]
 
     Notes
     -----

--- a/pygerm/client/__init__.py
+++ b/pygerm/client/__init__.py
@@ -57,10 +57,10 @@ def event2payload(chip, chan, td, pd, ts):
     # 2 words of 32 bit per data
     payload = np.zeros(len(chip)*2, dtype='<u4')
     # TODO sort out if this can be made faster!
-    #word1 = data[::2]
-    #word2 = data[1::2]
+    # word1 = data[::2]
+    # word2 = data[1::2]
     # for word 1
-    payload[::2] = (chip << 27) + (chan << 22) + (td << 12)  + pd
+    payload[::2] = (chip << 27) + (chan << 22) + (td << 12) + pd
     # for word 2
     payload[1::2] = 1 << 31 + ts
 
@@ -104,8 +104,8 @@ class ZClient:
     def parse_message(self, topic, payload):
 
         if topic == self.TOPIC_DATA:
-            payload = parse_event_payload(
-                np.frombuffer(payload, np.uint64))
+            payload = payload2event(
+                np.frombuffer(payload, np.uint32))
         else:
             payload = np.frombuffer(payload, np.uint32)
         return topic, payload

--- a/pygerm/handler.py
+++ b/pygerm/handler.py
@@ -2,7 +2,7 @@ from databroker.assets.handlers_base import HandlerBase
 import h5py
 import numpy as np
 
-from .client import parse_event_payload, DATA_TYPEMAP
+from .client import parse_event_payload2, DATA_TYPEMAP
 
 
 class GeRMHandler(HandlerBase):
@@ -24,24 +24,26 @@ class BinaryGeRMHandler(HandlerBase):
 
     def __init__(self, fpath):
         # TODO : don't save the raw data (here for debugging)
-        raw_data = np.fromfile(fpath, dtype='>u8')
+        raw_data = np.fromfile(fpath, dtype='>u4')
         # TODO : when simulated data comes in, verify this is correct
         # endianness and correct for it, don't just raise error
-        first_word = raw_data[0] & np.uint64(0xffffffff00000000)
-        if first_word != 0xfeedface00000000:
+        first_word = raw_data[0]
+        '''
+        if first_word != 0xfeedface:
             msg = "Error, first 32 bit word not 0xfeedface"
             msg += f"\n Got {first_word:#x} instead"
             raise ValueError(msg)
 
-        last_word = raw_data[-1] & np.uint64(0xffffffff)
+        last_word = raw_data[-1]
         if last_word != 0xdecafbad:
             msg = "Error, first 32 bit word not 0xdecafbad"
             msg += f"\n Got {last_word:#x} instead"
             raise ValueError(msg)
+        '''
 
         # remove first and last region
         raw_data = raw_data[1:-1]
-        self.data = parse_event_payload(raw_data)
+        self.data = parse_event_payload2(raw_data)
 
     def __call__(self, column):
         return self.data[DATA_TYPEMAP[column]]

--- a/pygerm/handler.py
+++ b/pygerm/handler.py
@@ -2,7 +2,7 @@ from databroker.assets.handlers_base import HandlerBase
 import h5py
 import numpy as np
 
-from .client import parse_event_payload2, DATA_TYPEMAP
+from .client import payload2event, DATA_TYPEMAP
 
 
 class GeRMHandler(HandlerBase):
@@ -28,7 +28,6 @@ class BinaryGeRMHandler(HandlerBase):
         # TODO : when simulated data comes in, verify this is correct
         # endianness and correct for it, don't just raise error
         first_word = raw_data[0]
-        '''
         if first_word != 0xfeedface:
             msg = "Error, first 32 bit word not 0xfeedface"
             msg += f"\n Got {first_word:#x} instead"
@@ -39,11 +38,10 @@ class BinaryGeRMHandler(HandlerBase):
             msg = "Error, first 32 bit word not 0xdecafbad"
             msg += f"\n Got {last_word:#x} instead"
             raise ValueError(msg)
-        '''
 
         # remove first and last region
         raw_data = raw_data[1:-1]
-        self.data = parse_event_payload2(raw_data)
+        self.data = payload2event(raw_data)
 
     def __call__(self, column):
         return self.data[DATA_TYPEMAP[column]]

--- a/pygerm/handler.py
+++ b/pygerm/handler.py
@@ -40,7 +40,7 @@ class BinaryGeRMHandler(HandlerBase):
             raise ValueError(msg)
 
         # remove first and last region
-        raw_data = raw_data[1:-1]
+        raw_data = raw_data[2:-2]
         self.data = payload2event(raw_data)
 
     def __call__(self, column):

--- a/pygerm/ophyd.py
+++ b/pygerm/ophyd.py
@@ -27,7 +27,7 @@ class GeRM(Device):
 
     # where the last file was written
     last_file = Cpt(EpicsSignalRO, ':last_file', string=True)
-    
+
     overfill = Cpt(EpicsSignalRO, ':overfill')
     last_frame = Cpt(EpicsSignalRO, ':last_frame')
 

--- a/pygerm/tests/test_binarygerm.py
+++ b/pygerm/tests/test_binarygerm.py
@@ -75,9 +75,10 @@ def test_binary_germ():
     fpath = tempfile.mktemp()
 
     germ_data = generate_germ_data()
-    germ_data.astype('>i4').tofile(fpath)
+    germ_data.astype('>u4').tofile(fpath)
     # strip first and last bit of payload
     # (endianness not issue here since this was generated from memory)
+
     chip, chan, td, ps, ts = payload2event(germ_data[2:-2])
 
     # instantiate the handler

--- a/pygerm/tests/test_binarygerm.py
+++ b/pygerm/tests/test_binarygerm.py
@@ -1,7 +1,7 @@
 import numpy as np
 import tempfile
 
-from pygerm.zmq import parse_event_payload
+from pygerm.client import payload2event, event2payload
 from pygerm.handler import BinaryGeRMHandler
 
 '''
@@ -11,24 +11,8 @@ use np.uint64(0x111) typecasting for every unit wise operation
 '''
 
 
-def payload2germ(chip, chan, td, pd, ts):
-    '''
-        Reverse the mapping of GERM data type.
-        This should reverse pygerm.zmq.parse_event_data
-    '''
-    # uses numpy broadcasting
-    # |= to ensure data is still np.uint64
-    data = np.zeros(len(chip), dtype=np.uint64)
-    data |= (chip << 27)
-    data |= (chan << 22)
-    data |= (td << 12)
-    data |= pd
-    data |= ts << 32
-    return data
-
-
-def generate_germ_data():
-    ''' Generate random germ data
+def generate_payload():
+    ''' Generate random payload data from a GeRM detector.
 
         This generates the contents of the germ packet described in the GeRM
         format documentation for the binary file.
@@ -36,19 +20,24 @@ def generate_germ_data():
         The full packet is:
         32-bit uint : 0xfeedface
         32-bit uint
-        [list of 64-bit uints of GeRM data]
+        [list of 32-bit uints of GeRM data two words per GeRM data]
         32-bit uint
         32-bit uint : 0xdecafbad
 
         where the list of 64-bit uints of GeRM data is what this function
         returns.
+
+        NOTE : "Word" is defined here as a 32 bit unsigned int.
+            Note that word normally means the pointer size for memory address
+            (64bit in 64bit machines instead of 32 for example)
     '''
     # number of elements
     N = 3000
 
     # generate some random unsigned ints
     def generate_data(N):
-        return np.random.randint(low=0, high=1000, size=N, dtype='uint32')
+        # <u4 little endian unsigned 4 byte int
+        return np.random.randint(low=0, high=1000, size=N, dtype='<u4')
 
     chip = generate_data(N)
     chan = generate_data(N)
@@ -56,22 +45,27 @@ def generate_germ_data():
     pd = generate_data(N)
     ts = generate_data(N)
 
-    germ_data = payload2germ(chip, chan, td, pd, ts)
+    payload = event2payload(chip, chan, td, pd, ts)
 
-    return germ_data
+    return payload
 
 
-def generate_germ_packet():
-    germ_data = generate_germ_data()
+def generate_germ_data():
+    payload = generate_payload()
 
-    germ_binary = np.zeros(len(germ_data)+2, dtype=np.uint64)
+    germ_data = np.zeros(len(payload)+4, dtype='<u4')
 
     # slicing preserves the data type
-    germ_binary[1:-1] = germ_data
-    germ_binary[0] = 0xfeedface00000000
-    germ_binary[-1] = 0xdecafbad
+    germ_data[2:-2] = payload
+    # some 
+    germ_data[0] = 0xfeedface
+    # frame number
+    germ_data[1] = 0
+    # events lost to overflow
+    germ_data[-2] = 0
+    germ_data[-1] = 0xdecafbad
 
-    return germ_binary
+    return germ_data
 
 
 def test_binary_germ():
@@ -80,11 +74,11 @@ def test_binary_germ():
     # make the tempfile
     fpath = tempfile.mktemp()
 
-    germ = generate_germ_packet()
-    germ.tofile(fpath)
+    germ_data = generate_germ_data()
+    germ_data.astype('>i4').tofile(fpath)
     # strip first and last bit of payload
     # (endianness not issue here since this was generated from memory)
-    chip, chan, td, ps, ts = parse_event_payload(germ[1:-1])
+    chip, chan, td, ps, ts = payload2event(germ_data[2:-2])
 
     # instantiate the handler
     handler = BinaryGeRMHandler(fpath)
@@ -101,18 +95,3 @@ def test_binary_germ():
     assert np.allclose(read_td, td)
     assert np.allclose(read_ps, ps)
     assert np.allclose(read_ts, ts)
-
-    uint64_dtype = np.dtype(np.uint64)
-    # assert dtype from what is read from file with handler
-    assert read_chip.dtype == uint64_dtype
-    assert read_chan.dtype == uint64_dtype
-    assert read_td.dtype == uint64_dtype
-    assert read_ps.dtype == uint64_dtype
-    assert read_ts.dtype == uint64_dtype
-
-    # and those returned by parse_event_payload
-    assert chip.dtype == uint64_dtype
-    assert chan.dtype == uint64_dtype
-    assert td.dtype == uint64_dtype
-    assert ps.dtype == uint64_dtype
-    assert ts.dtype == uint64_dtype

--- a/pygerm/tests/test_binarygerm.py
+++ b/pygerm/tests/test_binarygerm.py
@@ -57,7 +57,7 @@ def generate_germ_data():
 
     # slicing preserves the data type
     germ_data[2:-2] = payload
-    # some 
+    # some
     germ_data[0] = 0xfeedface
     # frame number
     germ_data[1] = 0

--- a/pygerm/tests/test_hdf5germ.py
+++ b/pygerm/tests/test_hdf5germ.py
@@ -1,3 +1,9 @@
+import numpy as np
+import h5py
+
+from pygerm.client import DATA_TYPEMAP, event2payload
+
+
 # some setup
 def open_file(fpath):
     return h5py.File(fpath, 'r')
@@ -16,6 +22,7 @@ def hdf52event(fpath):
 
     return elem_dict
 
+
 def hdf52germ(fpath):
     res = hdf52event(fpath)
     # TODO : make this more formal
@@ -25,4 +32,4 @@ def hdf52germ(fpath):
     new_dict['td'] = res['timestamp_fine']
     new_dict['pd'] = res['energy']
     new_dict['ts'] = res['timestamp_coarse']
-    return payload2germ(**new_dict)
+    return event2payload(**new_dict)


### PR DESCRIPTION
File handler and modification of detector simulator. The main issue that is handled here is that the endianness of the simulated detector data was not the same as the magic numbers used to understand the endianness of the data.

Significant changes:
1. The incoming words are treated as 32-bit words rather than a 64-bit word. This helps with changing the endianness in an easy to read manner if necessary (which is performed on a 32 bit word basis).
2. Updated the test to correctly read the simulated detector data. We still need to test on real binary data. It is not clear whether it should be big or little endian.
3. Cleaned up the event payload generation and parsing to be contained in two functions: `event2payload` and `payload2event`.
4. Added `bin2num` but this is mainly a convenience routine for debugging (it can be removed)

Note : Word is misleading as it means the size of a pointer to address memory. It's 64 bits in 64 bit machines...


For example:
```python
from pygerm.handler import BinaryGeRMHandler

fpath = '/tmp/test_001.bin'
handler = BinaryGeRMHandler(fpath)

# access some element
read_chip = handler('chip')
read_chan = handler('chan')
read_td = handler('timestamp_fine')
read_ps = handler('energy')
read_ts = handler('timestamp_coarse')


# read data back into some array
n_chips = 12
n_chans = 32
mask_array = np.zeros((n_chips, n_chans), dtype=float)
data_array = np.zeros((n_chips, n_chans), dtype=float)
for i in range(len(read_chip)):
    chip, chan = read_chip[i], read_chan[i]
    if chip < n_chips and chan < n_chans:
        data_array[chip][chan] += read_ps[i]
        mask_array[chip][chan] += 1
    else:
        print("Warning, found a value out of range (check n_chips and n_chans)")

data_array = data_array/mask_array

# forgive me for this unpythonic syntax!
from pylab import *
# use in ipython
ion()

figure(2);clf();
plot(read_chip, read_chan, 'ro')
xlabel("chip (0-12)")
ylabel("chan (0-32)")

figure(3);clf();
imshow(data_array)
xlabel("n_chan")
ylabel("n_chip")
```

![image](https://user-images.githubusercontent.com/705366/32999980-44df5e30-cd73-11e7-82c1-41b71590cb5d.png)

In this case, the binary file was generated by `det_sim` (see https://github.com/NSLS-II/GeRM/pull/4)

Note : endianness is still not confirmed, but it will be a matter of changing `>u4` to `<u4` in the code..